### PR TITLE
Handle absolute paths when resolving missing includes

### DIFF
--- a/vpp.pl
+++ b/vpp.pl
@@ -345,7 +345,14 @@ sub ScanText {
           }
           elsif ($loose_includes) {
             my ($base) = $file =~ /^(.+?)(?:\.[^.]*)?$/;
-            my $pattern = "{" . join(",", @incdirs) . "}/$base.*";
+            my $pattern;
+            if ($file !~ /^\//) {
+              $pattern = "{" . join(",", @incdirs) . "}/$base.*";
+            }
+            else {
+              $pattern = "$base.*";
+              $rest = basename($file)
+            }
             my @files = glob($pattern);
             if (@files) {
               $dir = dirname($files[0]);


### PR DESCRIPTION
This PR improves the handling of missing includes (in the so-called "loose includes" mode whereby a missing include can be determined to be serviced by a to-be-generated file of the same base filename with a different extension for dependency generation purposes) when the included path is an absolute path.