### PR TITLE
Also export variables with numeric characters in the stem to defines

### DIFF
--- a/vpp.pl
+++ b/vpp.pl
@@ -507,7 +507,7 @@ if ($perl_mode) {
     $outstring .= "`define $guard_name\n";
     foreach my $name (grep {ref(\${main::{$_}}) eq 'GLOB'} sort keys %main::) {
       if (defined ${*{$main::{$name}}{SCALAR}}) {
-        if (not exists $existing_scalars{$name} and $name =~ /^[A-Za-z]+_/) {
+        if (not exists $existing_scalars{$name} and $name =~ /^[A-Za-z][0-9A-Za-z]*_/) {
             $outstring .= "`define " . uc($name) . " " . ${*{$main::{$name}}{SCALAR}} . "\n";
         }
       }


### PR DESCRIPTION
This PR fixes a bug that keeps Perl variables with numeric characters in the "stem" (part before the first underscore) from being exported as Verilog  `` `define ``s when `--perldefines` is used.