### PR TITLE
Emit guards around Perl variables exported as Verilog defines

### DIFF
--- a/vpp.pl
+++ b/vpp.pl
@@ -509,7 +509,9 @@ if ($perl_mode) {
     foreach my $name (grep {ref(\${main::{$_}}) eq 'GLOB'} sort keys %main::) {
       if (defined ${*{$main::{$name}}{SCALAR}}) {
         if (not exists $existing_scalars{$name} and $name =~ /^[A-Za-z][0-9A-Za-z]*_/) {
+            $outstring .= "`ifndef " . uc($name) . "\n";
             $outstring .= "`define " . uc($name) . " " . ${*{$main::{$name}}{SCALAR}} . "\n";
+            $outstring .= "`endif\n";
         }
       }
     }


### PR DESCRIPTION
This PR emits guards around each (System)Verilog `define` that originate from Perl variables to avoid re-definition warnings (because the same Perl variable definition can be inherited into multiple contexts in the Perl-templating domain, so the per-file guards are not enough).

For example:
```
...
`ifndef FAB_CHUNK_SIZE
`define FAB_CHUNK_SIZE 16
`endif
`ifndef FAB_CHUNKS_PER_CELL
`define FAB_CHUNKS_PER_CELL 8
`endif
...
```