### PR TITLE
Fix aliasing of Perl files required  with relative paths

### DIFF
--- a/vpp.pl
+++ b/vpp.pl
@@ -456,7 +456,6 @@ if ($perl_mode) {
         if (-f "$prefix/$expr") {
           $expr = "$prefix/$expr";
           $dir = dirname($expr);
-          $expr = basename($expr);
           if (!grep {abs_path($_) eq abs_path($dir)} @INC) {
             push(@INC, $dir);
           }


### PR DESCRIPTION
This PR fixes the unintended aliasing of `.pl` files `require`d via relative paths (which as a side-effect adds the relative path directory to `@INC` as a convenience) by not reducing the actual `require`d filename down to is basename.